### PR TITLE
support for coffee-lake (158)

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -34,6 +34,7 @@ enum {
     CPU_MDL_SKX = 85,
     CPU_MDL_SPR = 143,
     CPU_MDL_ADL = 151,
+    CPU_MDL_CFL = 158, //coffee lake in laptop. 
     CPU_MDL_GNR = 173,
     CPU_MDL_SRF = 175,
     CPU_MDL_LNL = 189,

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -41,6 +41,10 @@ ModelContext model_ctx[] = {{CPU_MDL_BDX,
                              {
                                  "/sys/bus/event_source/devices/uncore_cbo_%u/type",
                              }},
+                            {CPU_MDL_CFL,
+                             {
+                                 "/sys/bus/event_source/devices/uncore_cbox_%u/type",
+                             }},
                             {CPU_MDL_LNL,
                              {
                                  "/sys/bus/event_source/devices/uncore_cbox_%u/type",


### PR DESCRIPTION
Hi Yiwei,
  Added support for my laptop configuration (158). Tested it with the following configuration.   
# ./CXLMemSim -t ./microbench/malloc -p 10 -l 200,250,200,250,200,250 -b 50,50,50,50,50,50

Output is attached. Thank you so much for the great work. 
[malloc_out.txt](https://github.com/user-attachments/files/19801538/malloc_out.txt)
