### PR TITLE
update cmake_minimum_required to 3.25.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.25.0)
 project(CXLMemSim VERSION 0.1.0)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
According to CMake document, [CXX_STANDARD](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html)

> C++26. CMake 3.25 and later recognize 26 as a valid value

because line 12 set C++ standard to 26, so I think the minimum version of CMake should be 3.25.0